### PR TITLE
Fix (css): Fix trainer speech LF characters not showing except the cursor's

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -469,8 +469,7 @@ speech value character {
     line-height: 1.5vw;
 }
 speech value character.line-feed {
-    /* border: 1px solid transparent; */
-    display: none;
+    border: 1px solid transparent;
 }
 speech value character.cursor {
     display: inline-block;


### PR DESCRIPTION
Fixes #13 

This bug affects all version since v0.10.0