### PR TITLE
Fix (css): Fix Trainer speech shifting slightly to the right when trainer speech cursor hits an LF

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -468,6 +468,9 @@ speech value character {
     font-size: 1.5vw;
     line-height: 1.5vw;
 }
+speech value character.line-feed-placeholder {
+    border: 1px solid transparent;
+}
 speech value character.line-feed {
     border: 1px solid transparent;
 }


### PR DESCRIPTION
Fixes #15 

This bug affects all version since v0.10.0