### PR TITLE
Fix (css): Fix too little padding-bottom for environment virtues export button

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -467,7 +467,7 @@ menuexport label {
 menuexport download {
     display: inline-block;
     vertical-align: middle;
-    height: calc(1vw + 2px + 2px);
+    height: calc(1vw + 4px + 2px);
     padding: 2px 1vw;
     border: 1px solid #fff;
     border-radius: 999px;


### PR DESCRIPTION
This bug affects all version from v0.21.0 and up