### PR TITLE
Fix (css): Remove extra spaces in statistics components

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -812,7 +812,7 @@ statistics globaloverall span {
     statistics unitprogress hitpercentagecounter,
     statistics unitprogress misscounter,
     statistics unitprogress misspercentagecounter {
-        font-size: 3vw;
+        display: block;
     }
     statistics unitprogress label,
     statistics unitprogress value,
@@ -842,7 +842,7 @@ statistics globaloverall span {
     statistics unitoverall amendpercentagecounter,
     statistics unitoverall othercounter,
     statistics unitoverall otherpercentagecounter {
-        font-size: 3vw;
+        display: block;
     }
     statistics unitoverall label,
     statistics unitoverall value,
@@ -873,7 +873,7 @@ statistics globaloverall span {
     statistics globaloverall othercounter,
     statistics globaloverall otherpercentagecounter,
     statistics globaloverall bookcounter {
-        font-size: 3vw;
+        display: block;
     }
     statistics globaloverall label,
     statistics globaloverall value,

--- a/index.html
+++ b/index.html
@@ -64,27 +64,27 @@
           <unitprogress>
             <heading>P R O G R E S S</heading>
             <characterscounter>
-                <label>Characters:</label>
-                <value></value><span>&nbsp;/&nbsp;</span><total></total>
-              </characterscounter>
+              <label>Characters: </label>
+              <value></value><span>&nbsp;/&nbsp;</span><total></total>
+            </characterscounter>
             <characterspercentagecounter>
-                <label>Characters (%):</label>
+                <label>Characters (%): </label>
               <value></value>
             </characterspercentagecounter>
             <hitcounter>
-              <label>Hits:</label>
+              <label>Hits: </label>
               <value></value>
             </hitcounter>
             <hitpercentagecounter>
-              <label>Hits (%):</label>
+              <label>Hits (%): </label>
               <value></value>
             </hitpercentagecounter>
             <misscounter>
-              <label>Misses:</label>
+              <label>Misses: </label>
               <value></value>
             </misscounter>
             <misspercentagecounter>
-              <label>Misses (%):</label>
+              <label>Misses (%): </label>
               <value></value>
             </misspercentagecounter>
           </unitprogress>
@@ -92,51 +92,51 @@
           <unitoverall>
             <heading>U N I T</heading>
             <datetimestart>
-              <label>Date:</label>
+              <label>Date: </label>
               <value></value>
             </datetimestart>
             <datetimestopwatch>
-              <label>Duration:</label>
+              <label>Duration: </label>
               <value></value>
             </datetimestopwatch>
             <shotcounter>
-              <label>Shots:</label>
+              <label>Shots: </label>
               <value></value>
             </shotcounter>
             <ratehitpermincounter>
-              <label>Hits / min:</label>
+              <label>Hits / min: </label>
               <value></value>
             </ratehitpermincounter>
             <hitcounter>
-              <label>Hits:</label>
+              <label>Hits: </label>
               <value></value>
             </hitcounter>
             <hitpercentagecounter>
-              <label>Hits (%):</label>
+              <label>Hits (%): </label>
               <value></value>
             </hitpercentagecounter>
             <misscounter>
-              <label>Misses:</label>
+              <label>Misses: </label>
               <value></value>
             </misscounter>
             <misspercentagecounter>
-              <label>Misses (%):</label>
+              <label>Misses (%): </label>
               <value></value>
             </misspercentagecounter>
             <amendcounter>
-              <label>Amends:</label>
+              <label>Amends: </label>
               <value></value>
             </amendcounter>
             <amendpercentagecounter>
-              <label>Amends (%):</label>
+              <label>Amends (%): </label>
               <value></value>
             </amendpercentagecounter>
             <othercounter>
-              <label>Other:</label>
+              <label>Other: </label>
               <value></value>
             </othercounter>
             <otherpercentagecounter>
-              <label>Other (%):</label>
+              <label>Other (%): </label>
               <value></value>
             </otherpercentagecounter>
           </unitoverall>
@@ -144,51 +144,51 @@
           <globaloverall>
             <heading>G L O B A L</heading>
             <datetimestopwatch>
-              <label>Duration:</label>
+              <label>Duration: </label>
               <value></value>
             </datetimestopwatch>
             <shotcounter>
-              <label>Shots:</label>
+              <label>Shots: </label>
               <value></value>
             </shotcounter>
             <ratehitpermincounter>
-              <label>Hits / min:</label>
+              <label>Hits / min: </label>
               <value></value>
             </ratehitpermincounter>
             <hitcounter>
-              <label>Hits:</label>
+              <label>Hits: </label>
               <value></value>
             </hitcounter>
             <hitpercentagecounter>
-              <label>Hits (%):</label>
+              <label>Hits (%): </label>
               <value></value>
             </hitpercentagecounter>
             <misscounter>
-              <label>Misses:</label>
+              <label>Misses: </label>
               <value></value>
             </misscounter>
             <misspercentagecounter>
-              <label>Misses (%):</label>
+              <label>Misses (%): </label>
               <value></value>
             </misspercentagecounter>
             <amendcounter>
-              <label>Amends:</label>
+              <label>Amends: </label>
               <value></value>
             </amendcounter>
             <amendpercentagecounter>
-              <label>Amends (%):</label>
+              <label>Amends (%): </label>
               <value></value>
             </amendpercentagecounter>
             <othercounter>
-              <label>Other:</label>
+              <label>Other: </label>
               <value></value>
             </othercounter>
             <otherpercentagecounter>
-              <label>Other (%):</label>
+              <label>Other (%): </label>
               <value></value>
             </otherpercentagecounter>
             <bookcounter>
-              <label>Books:</label>
+              <label>Books: </label>
               <value></value><span>&nbsp;/&nbsp;</span><total></total>
             </bookcounter>
           </globaloverall>


### PR DESCRIPTION
Fixes #78

Remove font-size for all statistics components' wrapper element to ensure there are no extra spaces in the components.