### PR TITLE
Refactor: Use dedicated element for app background

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -10,17 +10,9 @@ html {
 }
 
 body {
-    background: #fff;
-    /* color: #000; */
     font-size: 0;
 
     overflow: visible !important;
-    background: linear-gradient(90deg, #085078 10%, #85d8ce 90%);
-    background: linear-gradient(90deg, rgb(0, 186, 255) 10%, rgb(248, 255, 223) 90%);
-    background: linear-gradient(45deg, rgb(0, 170, 234) 70%, rgb(248, 255, 223) 100%);
-    background: linear-gradient(45deg, rgb(0, 186, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
-    background: linear-gradient(45deg, rgb(112, 201, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
-    background-attachment:fixed;
 }
 
 div {
@@ -48,6 +40,14 @@ span {
 /* Our styles */
 wrapper {
     display: block;
+}
+wrapper background {
+    content: "";
+    position: fixed;
+    background: linear-gradient(45deg, rgb(112, 201, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
 }
 
 home {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2576,7 +2576,7 @@ var EnvironmentController = function() {
                         c.props._training.trainer.memory.environment.ambience = ele.name;
                         // Set backgrounds on UI
                         var backgroundImage = c.props.ambiences[ele.name];
-                        document.body.style.backgroundImage = backgroundImage;
+                        document.getElementsByTagName('background')[0].style.backgroundImage = backgroundImage;
                         // Update choices
                         c.methods.updateChoices(c);
                     });

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
 <body>
   <wrapper>
+    <background></background>
 
     <home>
       <header>


### PR DESCRIPTION
Resolves #75

Do not use background-attachment style on body element which suffers performance issues when scrolling leading to flashes of unstyled background, especially on mobile.

Instead, use a dedicated background element which is rendered only each time the viewport changes.