### PR TITLE
 Refactor (css): Use a non-fixed app background

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,20 +7,13 @@
 
 html {
     display: block;
+    min-height: 100%;
 }
 
 body {
-    background: #fff;
-    /* color: #000; */
+    background-image: linear-gradient(45deg, rgb(112, 201, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
+    background-repeat: no-repeat;
     font-size: 0;
-
-    overflow: visible !important;
-    background: linear-gradient(90deg, #085078 10%, #85d8ce 90%);
-    background: linear-gradient(90deg, rgb(0, 186, 255) 10%, rgb(248, 255, 223) 90%);
-    background: linear-gradient(45deg, rgb(0, 170, 234) 70%, rgb(248, 255, 223) 100%);
-    background: linear-gradient(45deg, rgb(0, 186, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
-    background: linear-gradient(45deg, rgb(112, 201, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
-    background-attachment:fixed;
 }
 
 div {


### PR DESCRIPTION
Addresses #75

Previously, background-attachment:fixed renders the background based on the viewport's width and height. The background is fixed while scrolling. However, this causes rendering issues especially on mobile browsers where there might be flashes of unstyled backgrounds at the bottom of the viewport.

This MR removes background-attachment: fixed, and uses a regular background. The background moves while scrolling.

However, on mobile safari, at page init while <script> tags are still loading, if the user scrolls, the background clips at the bottom on viewport.