### PR TITLE
Fix: Fix Memory.fetch to only be considered successful on HTTP code 200

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -824,7 +824,7 @@ var Memory = function() {
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 var status = xhr.status;
-                if (status === 0 || (status >= 200 && status < 400)) {
+                if (status === 200) {
                     // Success
                     if (callback) {
                         callback.apply(callbackData.self, [ readbody(xhr), callbackData ]);


### PR DESCRIPTION
This bug affects all version since v0.55.1. status >= 201 are not GET success responses. xhr always follow redirects so 30x status is not needed. 40x is non-200. Hence simply enforce 200.