### PR TITLE
Fix (js): Fix Component.creatingBindings() adding duplicate independent eventListeners

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1496,12 +1496,12 @@ var Component = function(c) {
 
     var creatingBindings = function(rootElement) {
         var allElements = rootElement.getElementsByTagName('*');
-        var matches, split, events, propsPaths, object, property, binding, addedBinding;
+        var matches, split, events, addBinding, propsPaths, object, property, binding, addedBinding;
 
         // Parse elements
         for (var ele, i = 0; i < allElements.length; i++) {
             ele = allElements[i];
-            events = [];
+            events = [], addBinding = false;
 
             // Parse attributes for events
             for (var j = 0, atts = ele.attributes; j < atts.length; j++) {
@@ -1523,8 +1523,6 @@ var Component = function(c) {
 
             // Parse attributes for data binding
             for (var j = 0, atts = ele.attributes; j < atts.length; j++) {
-                addedBinding = false;
-
                 // Create data binding to attribute.
                 // E.g. <element someattribute="{{ .foo }}" /> or <element someattribute="{{ .foo.bar }}" />
                 binding = null;


### PR DESCRIPTION
Fix (js): Fix Component.creatingBindings() adding duplicate independent eventListeners

Bug affects all version since v0.54.1.

This bug is reproduceable when an element has more than 3 attributes, e.g:
`<element b-on="DOMContentLoaded" title="{{ .someProp }}" alt="foo"></element>`

- b-on is parsed and ignored (correct)
- data-binding with eventListener added for element.title (correct)
- eventListener setup for alt (incorrect)

As seen above, the independently added eventListeners are duplicate eventListeners..