### PR TITLE
Fix (Component): Fix independent eventListeners calling wrong callback

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1627,9 +1627,10 @@ var Component = function(c) {
             // If there is no data binding, simply set up the eventListeners
             if (!addedBinding) {
                 if (events.length > 0) {
-                    for (var _ele, handler, _ = 0; _ < events.length; _++) {
+                    for (var _ele, _ = 0; _ < events.length; _++) {
                         _ele = /DOM|ready/.test(events[_].event) ? document : ele;
-                        handler = events[_].handler;
+                        // Use a const here to ensure the event callback closure references a unique variable
+                        const handler = events[_].handler;
                         _ele.addEventListener(events[_].event, function(e){
                             c.eventsListeners[handler].apply(c, [e]);
                         });


### PR DESCRIPTION
Bug affects all version since v0.69.0.

This bug is due to preservation of variable reference when a variable is used in a loop, such  that usage of that variable in `callback` in `<element>.addEventListener('foo', callback)` now references its finalmost value before the loop exits.

The solution is to use const in the loop. By using const within the loop, a new variable is created for each loop, such that the variable is not reused in the `callback`.