### PR TITLE
Fix (css): Hide outline when focused on ambiences component

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -458,6 +458,7 @@ menuambienceswitch ambiences {
     display: inline-block;
     width: calc(100vw * 2 / 3 * 2 / 3);
     vertical-align: middle;
+    outline: none;
 }
 menuambienceswitch ambiences:focus-visible {
     outline: none;


### PR DESCRIPTION
Bug affects all version since v0.72.0, on certain older browsers which render an outline for TAB-focusable elements.

Follow-up of #125