### PR TITLE
Fix (regression): Fix environment virtues download failing for mouse clicks

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3219,7 +3219,7 @@ var EnvironmentController = function() {
             click: function(event) {
                 var c = this;
                 // var ele = event.target || event.srcElement;
-                c.methods.beginDownload();
+                c.methods.beginDownload(c);
 
                 event.stopPropagation();
             },


### PR DESCRIPTION
Bug affects all versions since v0.72.0

Regression introduced in #115.