### PR TITLE
Fix (Component): Fix regression where independent eventListeners are not added

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1674,12 +1674,12 @@ var Component = function(c) {
 
     var creatingBindings = function(rootElement) {
         var allElements = rootElement.getElementsByTagName('*');
-        var matches, split, events, setters, addBinding, propsPaths, object, property, binding, addedBinding;
+        var matches, split, events, setters, propsPaths, object, property, binding, addedBinding;
 
         // Parse elements
         for (var ele, i = 0; i < allElements.length; i++) {
             ele = allElements[i];
-            events = [], setters = [], addBinding = false;
+            events = [], setters = [], addedBinding = false;
 
             // Parse attributes for events
             for (var j = 0, atts = ele.attributes; j < atts.length; j++) {


### PR DESCRIPTION
This bug affects all version since v0.71.1.

Introduced in #111, due to a wrong variable name.

In particular, the environment library add button functionality was broken.