### PR TITLE
Fix (environment): Replace background with box-shadow for TAB-focused select element

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -317,7 +317,7 @@ menuselect select {
 }
 menuselect select:focus-visible {
     outline: none;
-    background: rgba(255, 255, 255, 0.25);
+    box-shadow: inset 0 0 1vw 0vw;
 }
 menuselect select option {
     font-family: monospace;
@@ -415,6 +415,9 @@ menuselect add:focus-visible {
         height: calc(2vw + 4px + 2px);
         padding: 2px;
         font-size: 2vw;
+    }
+    menuselect select:focus-visible {
+        box-shadow: inset 0 0 2vw 0vw;
     }
     menuselect select option {
         font-size: 2vw;


### PR DESCRIPTION
Bug affects all versions since v0.72.0.

Bug introduced in #120.

This fixes issue where the background opacity works for :focus-visible on the select when it is unopened, but when it is opened, the background applies to the select element's option elements and is stuck to a value of 1. This issue seems to only occur on later versions of firefox.