### PR TITLE
Fix (Component): Fix component root element binding configuration not being parsed

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1721,7 +1721,13 @@ var Component = function(c) {
     };
 
     var creatingBindings = function(rootElement) {
-        var allElements = rootElement.getElementsByTagName('*');
+        // Get all elements
+        var allElements = [ rootElement ];
+        var myElements = rootElement.getElementsByTagName('*');
+        for (var i = 0; i < myElements.length; i++) {
+            allElements.push(myElements[i]);
+        }
+
         var matches, split, events, setters, propsPaths, object, property, binding, addedBinding;
 
         // Parse elements


### PR DESCRIPTION
Bug affects all versions since v0.18.1. Since none of the components so far declare configuration on their root element, this bug was not experienced.