### PR TITLE
Fix (environment): Remove unneeded query parameters in favorite URL

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1011,7 +1011,7 @@ var Memory = function() {
         return book;
     };
 
-    var getFullEnvironment = function() {
+    var getFullEnvironment = function(sanitise) {
         var fullEnvironment = {};
         for (var k in environment) {
             if (typeof environment[k] === 'boolean' || typeof environment[k] === 'string') {
@@ -1022,6 +1022,16 @@ var Memory = function() {
         fullEnvironment.bookLibraryIds = this.workingMemoryLibraryId;
         fullEnvironment.bookCollectionIds = this.workingMemoryCollectionId;
         fullEnvironment.bookIds = this.workingMemoryBookId;
+
+        if (sanitise) {
+            // Remove unneeded properties
+            if (! /^https:\/\//.test(fullEnvironment.bookLibraryIds)) {
+                delete fullEnvironment.bookLibraryIds;
+            }
+            if (! /^https:\/\//.test(fullEnvironment.bookCollectionIds)) {
+                delete fullEnvironment.bookCollectionIds
+            }
+        }
 
         return fullEnvironment;
     }
@@ -3857,7 +3867,7 @@ var EnvironmentController = function() {
         },
         methods: {
             copyFavorite: function(c) {
-                var fullEnvironment = _training.trainer.memory.getFullEnvironment();
+                var fullEnvironment = _training.trainer.memory.getFullEnvironment(true);
 
                 // Convert object keys to underscore convention
                 var fullEnvironmentUnderscores = Helpers.convertToUnderscores(fullEnvironment);


### PR DESCRIPTION
Fixes bug in #144.

Bug affects all versions since v0.75.0.

If the environment library or collection is empty, then the favorite should also omit those query parameters. For instance, when a query-parameters-configured touchtypie instance omits `book_library_ids` or `book_collection_ids` query parameters, the favorite of that same session should not contain those query parameters as well.