### PR TITLE
Fix (environment): Create custom library or collection under query-parameter-configuration

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1136,15 +1136,18 @@ var Memory = function() {
             bookLibraryIds = Array.isArray(trainingConfig.bookLibraryIds) ? trainingConfig.bookLibraryIds : [ trainingConfig.bookLibraryIds ];
         }else {
             // Custom config
-            bookLibraryIds = [
-                'Custom library'
-            ];
+            // bookLibraryIds = [
+            //     'Custom library'
+            // ];
         }
 
         if ('bookIds' in trainingConfig) {
             // Custom bookIds
 
             // Create fake library
+            bookLibraryIds = [
+                'Custom library'
+            ];
             fakeEntities.bookLibrary = BookLibrary();
             fakeEntities.bookLibrary.id = 'Custom library';
             fakeEntities.bookLibrary.content = 'Custom collection';
@@ -1157,6 +1160,9 @@ var Memory = function() {
             // Custom bookCollectionIds
 
             // Create fake library
+            bookLibraryIds = [
+                'Custom library'
+            ];
             fakeEntities.bookLibrary = BookLibrary();
             fakeEntities.bookLibrary.id = 'Custom library';
             fakeEntities.bookLibrary.content = Array.isArray(trainingConfig.bookCollectionIds) ? trainingConfig.bookCollectionIds.join("\n") : trainingConfig.bookCollectionIds;


### PR DESCRIPTION
An expected effect of this change is that a favorite URL of a query-parameter-configured touchtypie instance would omit the `book_library_ids` or `book_collection_ids` query parameters.

In other words, a favorite is, as of this PR, a serialized configuration of a specific book.

Related: #210, #144