### PR TITLE
Fix (environment): Fix removal of unneeded query parameters in favorite URL

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1025,11 +1025,14 @@ var Memory = function() {
 
         if (sanitise) {
             // Remove unneeded properties
-            if (! /^https:\/\//.test(fullEnvironment.bookLibraryIds)) {
+            if (/^Custom /i.test(fullEnvironment.bookLibraryIds)) {
                 delete fullEnvironment.bookLibraryIds;
             }
-            if (! /^https:\/\//.test(fullEnvironment.bookCollectionIds)) {
-                delete fullEnvironment.bookCollectionIds
+            if (/^Custom /i.test(fullEnvironment.bookCollectionIds)) {
+                delete fullEnvironment.bookCollectionIds;
+            }
+            if (/^Custom /i.test(fullEnvironment.bookIds)) {
+                delete fullEnvironment.bookIds;
             }
         }
 


### PR DESCRIPTION
Previously #210 removed unneeded query parameters when they were non-URL-like. Now, unneeded query parameters are removed only if they are placeholders (in the form of 'Custom \<entity\>') i.e. entities (i.e. library, collection, or book) are unspecified among the query parameters configuration.