### PR TITLE
Fix (environment): Use pre-defined library if query parameters configuration omits library, collection and book

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3973,6 +3973,11 @@ var ConfigController = function(Config) {
         // Pre-defined config
         mergedConfig['bookLibraryIds'] = Config['bookLibraryIds'];
     }else {
+        if (! ('bookLibraryIds' in keys) && ! ('bookCollectionIds' in keys) && ! ('bookIds' in keys) ) {
+            // Pre-defined config
+            mergedConfig['bookLibraryIds'] = Config['bookLibraryIds'];
+        }
+
         // Custom GET config
         if (Object.keys(urlParamsCamelCased).length > 0) {
             for (var k in urlParamsCamelCased) {


### PR DESCRIPTION
Fixes bug in #209 where app init would fail under query parameters configuration when no library, collection, or book query parameter was specified, i.e. query parameters configuration omits all three of the following parameters: `book_library_ids`, `book_collection_ids`, `book_ids`. E.g. https://play.touchtypie.com/?ambience=sea

Now, if query parameters configuration omits all three of the following parameters: `book_library_ids`, `book_collection_ids`, `book_ids`, the default behavior is to fall back on the pre-defined library configuration.