### PR TITLE
Enhancement (speech): Make Trainer's Speech scrollable with full book text

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -638,14 +638,17 @@ speech {
     display: block;
 }
 speech speechwrapper {
+    position: relative;
     display: block;
-    margin: 0 auto;
+    margin: calc(2vw * 2 / 3) auto;
     width: calc(100vw * 2 / 3);
-    height: auto;
-    border: 1px solid transparent;
+    /* 5 Trainer Speech lines */
+    height: calc((1.5vw + 2px) * 5 + 1px + 1px);
+    border: 0px solid transparent;
     border-radius: 1.75vw;
-    padding: calc(2vw * 2 / 3);
+    padding: 0 calc(2vw * 2 / 3);
     cursor: text;
+    overflow-y: scroll;
 }
 speech value {
     display: block;
@@ -691,15 +694,26 @@ speech value character.invalid {
 speech value character.valid {
     border: 1px solid transparent;
 }
+speech.meditation speechwrapper {
+    /* 10 Trainer Speech lines */
+    height: calc((1.5vw + 2px) * 10 + 1px + 1px);
+}
 @media (max-aspect-ratio: 13/10) {
     speech speechwrapper {
+        margin: calc(4vw * 2 / 3) auto;
         width: calc(100vw * 5 / 6);
-        padding: calc(4vw * 2 / 3);
+        /* 5 Trainer Speech lines */
+        height: calc((3vw + 2px) * 5 + 1px + 1px);
+        padding: 0 calc(4vw * 2 / 3);
     }
     speech value character {
         height: calc(3vw + 2px);
         font-size: 3vw;
         line-height: 1;
+    }
+    speech.meditation speechwrapper {
+        /* 10 Trainer Speech lines */
+        height: calc((3vw + 2px) * 10 + 1px + 1px);
     }
 }
 


### PR DESCRIPTION
Closes #217

Related #176

Previously, book text in Trainer Speech would be truncated to 5 lines in non-meditation, and 10 lines in meditation.

Now, the full book text is contained in a scrollable Trainer Speech, and the Trainer scrolls the Speech to the Speech cursor every time a Student response is made.