### PR TITLE
Fix (speech): Ensure Trainer Speech scrolls to the Speech cursor when transitioning to Home scene

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4309,6 +4309,7 @@ var myApp = function () {
                         case 'environment':
                             sceneController.scene = 'home';
                             State.training.student.focus();
+                            Components.speech.methods.setSpeechScrollPosition(Components.speech);
                             break;
                         default:
                             break;


### PR DESCRIPTION
This fixes a bug where when perfection is swtiched on and the training session is restarted, that the Trainer Speech starts from the beginning.