### PR TITLE
Fix (meditation): Prevent margin collapsing of response component overflowing the top of Home scene

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -58,9 +58,6 @@ header {
     padding: 2vw;
     /* border-bottom: 1px solid #000; */
 }
-header.meditation {
-    display: none;
-}
 header heading {
     display: block;
     text-align: center;
@@ -81,6 +78,9 @@ header heading {
     font-family: monospace;
     font-size: 2vw;
     text-transform: uppercase;
+}
+header.meditation heading {
+    font-size: 0;
 }
 @media (max-aspect-ratio: 13/10) {
     header {


### PR DESCRIPTION
In particular the bug can be seen when the app is init in meditation, such that the Splash scene is "pushed down" relative to the Home scene, due to response component margin-top overflowing the Home scene.