### PR TITLE
Fix (meditation): Retain margin of footer component of Home scene in meditation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1032,9 +1032,6 @@ footer {
     margin-top: 2vw;
     margin-bottom: 2vw;
 }
-footer.meditation {
-    display: none;
-}
 footer icons {
     display: block;
     text-align: center;
@@ -1049,6 +1046,9 @@ footer icons > a {
 footer icons > a > svg {
     width: 3vw;
     fill: #fff;
+}
+footer.meditation icons {
+    display: none;
 }
 @media (max-aspect-ratio: 13/10) {
     footer {


### PR DESCRIPTION
Previously, in meditation, if statistics is turned on, there is no margin-bottom on the Home scene.

This change no longer uses `display: none` on the Home scene's footer component, but simply hides the footer's icons. Hence the margin of the footer component is retained.