### PR TITLE
Enhancement (performance): Truncate Trainer Speech when book text is longer than 10000 characters

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -363,7 +363,7 @@ var Bubble = function(default_value) {
     var disabled = false;
     var value = default_value;
     var charactersCounter = 0;
-    var maxLines = 0;   // No limit
+    var maxLines = 10;   // 10 lines by default
     var lineWidth = 0;
     var characterWidth = 0;
 
@@ -759,7 +759,7 @@ var Bubble = function(default_value) {
             virtue.result.value = truth.value;
         }
         var startIndex, endIndex;
-        if (speech.maxLines > 0 && speech.lineWidth > 0 && speech.characterWidth) {
+        if (truth.value.length > 10000 && speech.maxLines > 0 && speech.lineWidth > 0 && speech.characterWidth) {
             // Truncated speech
             const peekIndices = getPeekIndices(bubble, truth, speech.maxLines, speech.lineWidth, speech.characterWidth);
             startIndex = peekIndices[0];
@@ -2126,7 +2126,7 @@ var HomeController = function () {
                     }
                 }
             },
-            // Deprecated: Sets the trainer speech line and character widths. These will be useed to determine the presentation of speech.
+            // Sets the trainer speech line and character widths. These will be useed to determine the presentation of speech.
             setSpeechWidths: function(c) {
                 if (State.debug) {
                     console.log('[setSpeechWidths]');
@@ -2164,8 +2164,8 @@ var HomeController = function () {
                     // Initialize training the training with an trainer intro speech
                     c.props._training.start();
 
-                    // Deprecated: Set the speech widths based on the intro speech
-                    // c.methods.setSpeechWidths(c);
+                    // Set the speech widths based on the intro speech
+                    c.methods.setSpeechWidths(c);
 
                     // Scroll to Speech cursor
                     c.methods.setSpeechScrollPosition(c);
@@ -2179,8 +2179,8 @@ var HomeController = function () {
                             console.log('[resize]');
                         }
 
-                        // Deprecated: Set the speech widths based on the intro speech
-                        // c.methods.setSpeechWidths(c);
+                        // Set the speech widths based on the intro speech
+                        c.methods.setSpeechWidths(c);
 
                         // Scroll to Speech cursor
                         c.methods.setSpeechScrollPosition(c);


### PR DESCRIPTION
Closes #239

Previously, when book text is long e.g. > 10000 characters, the Trainer Speech requires the creation of a `<character>` element for each character for each Student response. Past 10000 characters, the app begins to show sluggishness.

Now, when book text is long e.g. > 10000 characters, the Trainer Speech is truncated and scoped only to the Speech cursor, creating only 10 Speech lines of `<character>` elements, which is much more performant. However, the Student loses the ability to review / read the entire book text during practice.

It is unfortunate that the deprecated Bubble.getPeekIndices() has to be used. There should definitely be a way to preserve performance without having to truncate the Trainer's Speech.
