### PR TITLE
Fix (statistics): Fix wrong determination of a miss as a hit in perfection

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -715,24 +715,28 @@ var Bubble = function(default_value) {
             })();
         }
         virtue.result.shot_num_new = key ? 1 : 0;
-        for (var i = 0; i < bubble.value.length && i < truth.value.length; i++) {
-            if (bubble.value[i] !== truth.value[i]) {
-                // Invalid
-                virtue.result.miss_indices.push(i);
-                if (
-                    (environment.perfection === true) ||
-                    (environment.perfection === false && i === bubble.value.length - 1 && bubble.value.length > value_length_prev)
-                   ) {
-                    virtue.result.miss_num_new = 1;
-                }
+        if (environment.perfection === true) {
+            if (bubble.value[bubble.value.length - 1] === truth.value[bubble.value.length - 1]) {
+                virtue.result.hit_indices.push(bubble.value.length - 1);
+                virtue.result.hit_num_new = 1;
             }else {
-                // Valid
-                virtue.result.hit_indices.push(i);
-                if (
-                    (environment.perfection === true) ||
-                    (environment.perfection === false && i === bubble.value.length - 1 && bubble.value.length > value_length_prev)
-                   ) {
-                    virtue.result.hit_num_new = 1;
+                virtue.result.miss_indices.push(bubble.value.length - 1);
+                virtue.result.miss_num_new = 1;
+            }
+        }else {
+            for (var i = 0; i < bubble.value.length && i < truth.value.length; i++) {
+                if (bubble.value[i] !== truth.value[i]) {
+                    // Invalid
+                    virtue.result.miss_indices.push(i);
+                    if (i === bubble.value.length - 1 && bubble.value.length > value_length_prev) {
+                        virtue.result.miss_num_new = 1;
+                    }
+                }else {
+                    // Valid
+                    virtue.result.hit_indices.push(i);
+                    if (i === bubble.value.length - 1 && bubble.value.length > value_length_prev) {
+                        virtue.result.hit_num_new = 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Bug affects all versions since v0.84.0.

Fixes bug in #207.

Previously, a bug caused a response miss to be determined to be a hit in perfection. This incorrectly caused hit values to be higher than book text length, and the sum of values and percentages of hits, misses, amends, and other to be greater than shots value and percentage (100%). Statistics of all versions since v0.84.0 are affected by this bug.

Now, in perfection, if a response value is correct, the response is determined to be a hit, and if the value is incorrect, the value is determined to be a miss. That is, only the response cursor's value is checked.

As a beneficial side effect of this change, Trainer Speech responsiveness is enhanced, since only the response cursor's value is checked, instead of the previous implementation where all response character values are checked.