### PR TITLE
Fix (environment): Raise favorite buttons' margins in viewport <= 13:10 aspect ratio

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -594,8 +594,9 @@ menufavorite:focus-within label {
 menufavorite copybutton {
     display: inline-block;
     vertical-align: middle;
-    height: calc(1vw + 4px + 2px);
     margin-right: 1vw;
+    width: auto;
+    height: calc(1vw + 4px + 2px);
     padding: 2px 1vw;
     border: 1px solid #fff;
     border-radius: 999px;
@@ -624,6 +625,7 @@ menufavorite copybutton:hover {
         font-size: 2vw;
     }
     menufavorite copybutton {
+        margin-right: 2vw;
         height: calc(2vw + 8px + 2px);
         padding: 4px 2vw;
         font-size: 2vw;


### PR DESCRIPTION
Bug affects all versions since v0.85.0.

Should have been implemented in #213.

The margins of the Environment scene favorite buttons in viewport <= 13:10 aspect ratio should be wider.