### PR TITLE
Fix (environment): Raise ambience choices' margins in viewport <= 13:10 aspect ratio

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -501,12 +501,13 @@ menuambienceswitch choice.active {
         font-size: 2vw;
     }
     menuambienceswitch choice {
+        margin-right: 2vw;
+        margin-bottom: 2vw;
         width: calc( 2vw + 4px + 2px );
         height: calc( 2vw + 4px + 2px );
         border-radius: 2vw;
         padding: 2px;
         font-size: 2vw;
-        margin-bottom: 1vw;
     }
     menuambienceswitch choice.active {
         box-shadow: 0 0 0.6vw 0.2vw #fff;


### PR DESCRIPTION
Bug affects all versions since v0.62.0.

Should have been implemented in #26.

The margins of the Environment scene ambiences choices in viewport <= 13:10 aspect ratio should be wider.