### PR TITLE
Enhancement (development): Update docker-compose.traefik.yml with traefik v1 and traefik v2 labels

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -7,9 +7,18 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=proxy-network"
+      # traefik v1
       - "traefik.frontend.rule=Host:touchtypie.example.com"
       - "traefik.port=80"
       - "traefik.frontend.headers.SSLRedirect=false"
+      - "traefik.frontend.headers.customResponseHeaders=Cache-Control:private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0||Pragma:no-cache"
+      # traefik v2
+      - "traefik.http.services.web.loadbalancer.server.port=80"
+      - "traefik.http.routers.web.entrypoints=web"
+      - "traefik.http.routers.web.rule=Host(`touchtypie.example.com`)"
+      - "traefik.http.routers.web.middlewares=nocache"
+      - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Cache-Control=private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"
+      - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Pragma=no-cache"
     volumes:
       - ./:/usr/share/nginx/html:ro
     # Enable networks for traefik


### PR DESCRIPTION
v1:
- Adds Cache-Control and Pragma headers to prevent caching in browser of proxy

v2:
- Uses a traefik entrypoint called 'web'
- Adds Cache-Control and Pragma headers to prevent caching in browser or proxy