### PR TITLE
Enhancement (development): Add traefik-v1 and traefik-v2 services in docker-compose.traefik.yml

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -5,27 +5,52 @@ services:
     image: nginx:1.14-alpine
     # Enable labels for traefik
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=proxy-network"
       # traefik v1
-      - "traefik.frontend.rule=Host:touchtypie.example.com"
       - "traefik.port=80"
-      - "traefik.frontend.headers.SSLRedirect=false"
+      - "traefik.frontend.entryPoints=web"
+      - "traefik.frontend.rule=HostRegexp:{catchall:.*}"
+      # - "traefik.frontend.rule=PathPrefix:/"
       - "traefik.frontend.headers.customResponseHeaders=Cache-Control:private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0||Pragma:no-cache"
       # traefik v2
       - "traefik.http.services.web.loadbalancer.server.port=80"
       - "traefik.http.routers.web.entrypoints=web"
-      - "traefik.http.routers.web.rule=Host(`touchtypie.example.com`)"
+      - "traefik.http.routers.web.rule=HostRegexp(`{catchall:.*}`)"
+      # - "traefik.http.routers.web.rule=PathPrefix(`/`)"
       - "traefik.http.routers.web.middlewares=nocache"
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Cache-Control=private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Pragma=no-cache"
     volumes:
       - ./:/usr/share/nginx/html:ro
-    # Enable networks for traefik
-    networks:
-      - proxy-network
 
-# Enable networks for traefik
-networks:
-  proxy-network:
-    external: true
+  # Run traefik v1 on port 8081
+  traefik-v1:
+    image: traefik:v1.7-alpine
+    ports:
+      - 8081:80
+    command:
+      # - --logLevel=DEBUG
+      - --docker
+      - --docker.watch
+      - --docker.exposedByDefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
+      - --entryPoints=Name:web Address::80
+    volumes:
+      # Allow traefik to listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  # Run traefik v2 on port 8080
+  traefik-v2:
+    image: traefik:v2.4
+    ports:
+      - 8080:80
+    command:
+      # - --log.level=DEBUG
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
+      - --entrypoints.web.address=:80
+    volumes:
+      # Allow traefik to listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+# The '<project_name>_default' network is created by docker-compose by default
+# networks:
+#   default:


### PR DESCRIPTION
This makes the docker-compose.yml completely self-contained, modular, and reusable across projects, with no external networks or reliance on an external traefik instance.
- Publish traefik-v2 on port 8080
- Publish traefik-v1 on port 8081
- Remove Host HTTP header rule. App may now be reached via `localhost:8080` or `localhost:8081`.

The reason for running traefik v1 alongside v2 is for backward compatibility. The docker provider configuration is very different between traefik v1 and v2 and some users might still prefer to use the v1 labels.

The removal of Host header rule decouples App from a specific hostname so that DNS or Host file entry is no longer needed, improving developer workflow.

## Demo

```
$ curl --head -L localhost:8080
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0
Content-Length: 4973
Content-Type: text/html
Date: Fri, 23 Jul 2021 12:04:17 GMT
Etag: "60c05fa2-136d"
Last-Modified: Wed, 09 Jun 2021 06:28:50 GMT
Pragma: no-cache
Server: nginx/1.14.2

$ curl --head -L localhost:8081
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0
Content-Length: 4973
Content-Type: text/html
Date: Fri, 23 Jul 2021 12:04:18 GMT
Etag: "60c05fa2-136d"
Last-Modified: Wed, 09 Jun 2021 06:28:50 GMT
Pragma: no-cache
Server: nginx/1.14.2
```