### PR TITLE
Enhancement (home): Add menu fullscreen button to Home scene to enter fullscreen programatically

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,6 +7,7 @@
 
 html {
     display: block;
+    height: 100%; /* Make body take up full html document height */
 }
 
 body {
@@ -21,6 +22,7 @@ body {
     background: linear-gradient(45deg, rgb(0, 186, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
     background: linear-gradient(45deg, rgb(112, 201, 255) 10%, rgb(0, 158, 217) 80%, rgb(248, 255, 223) 100%);
     background-attachment:fixed;
+    height: 100%; /* Make body take up full html document height. Especially needed for desktop Safari in programmatic fullscreen mode */
 }
 
 div {
@@ -96,7 +98,7 @@ menu {
     position: absolute;
     z-index: 1000;
     display: block;
-    top: 2.5vw;
+    top: 0vw;
     left: 2.5vw;
     padding: 0;
     -webkit-touch-callout: none; /* iOS Safari */
@@ -108,11 +110,12 @@ menu {
                                   supported by Chrome, Edge, Opera and Firefox */
 }
 menu menubutton {
-    display: inline-block;
+    display: block;
     cursor: pointer;
 }
 menu menubutton icon {
     display: block;
+    margin: 2.5vw 0;
     width: 3vw;
     height: 3vw;
     color: #fff;
@@ -123,6 +126,7 @@ menu menubutton icon {
 }
 @media (max-aspect-ratio: 13/10) {
     menu menubutton icon {
+        margin: 5vw 0;
         width: 6vw;
         height: 6vw;
         font-size: 6vw;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -151,6 +151,44 @@ var Helpers = function () {
             // Replace leading '&' with '?'
             return url.replace(/^&/, '?');
         },
+        isDesktopBrowser: function() {
+            // This will return true on Android.
+            // This will return false for iOS. iOS does not support fullscreen.
+            return navigator.platform.toUpperCase().indexOf('LINUX') >= 0 || navigator.platform.toUpperCase().indexOf('MAC') >= 0 || navigator.platform.toUpperCase().indexOf('WIN') >= 0;
+        },
+        isFullScreen: function() {
+            return document.fullscreenElement || // This should work on most modern browsers
+                document.webkitIsFullScreen || document.mozFullscreen ||  // This should work on older browsers
+                document.msFullscreenElement || document.fullscreenElement ||
+                document.fullscreen || document.webkitFullscreenElement ||
+                document.mozFullScreenElement ||
+                window.innerHeight == screen.height; // This might work for the rest
+        },
+        enterFullScreen: function(targetEle) {
+            var ele = targetEle || document.documentElement;
+            if (ele.requestFullScreen) {
+                ele.requestFullscreen();
+            }else if (ele.webkitRequestFullScreen) {
+                ele.webkitRequestFullScreen();
+            }else if (ele.mozRequestFullScreen) {
+                ele.mozRequestFullScreen();
+            }else if(ele.msRequestFullscreen) {
+                ele.msRequestFullscreen();
+            }
+        },
+        exitFullScreen: function(targetEle) {
+            var ele = targetEle || document.documentElement;
+            if (ele.requestFullscreen) {
+                console.log('exit');
+                document.exitFullscreen();
+            }else if (ele.webkitRequestFullscreen) {
+                document.webkitCancelFullScreen();
+            }else if (ele.mozRequestFullScreen) {
+                document.mozCancelFullScreen();
+            }else if(ele.msRequestFullscreen){
+                document.msExitFullscreen();
+            }
+        }
     };
 }()
 
@@ -2060,9 +2098,7 @@ var HomeController = function () {
         parentElement: document.getElementsByTagName('home')[0],
         name: 'menu_home',
         template: `
-            <menu>
-                <menubutton b-on="click"><icon>{{ .label }}</icon></menubutton>
-            </menu>
+            <menu></menu>
         `,
         props: {
             label: '⚙️',
@@ -2070,6 +2106,61 @@ var HomeController = function () {
         eventsListeners: {
             click: function(event) {
                 myApp.sceneController.scene = 'environment';
+            }
+        }
+    });
+    Component({
+        parentElement: Components.menu_home.rootElement,
+        name: 'menu_home_environmentbutton',
+        template: `
+            <menubutton b-on="click"><icon>{{ .label }}</icon></menubutton>
+        `,
+        props: {
+            label: '⚙️',
+        },
+        eventsListeners: {
+            click: function(event) {
+                myApp.sceneController.scene = 'environment';
+            }
+        }
+    });
+    Component({
+        parentElement: Components.menu_home.rootElement,
+        name: 'menu_home_fullscreenbutton',
+        template: `
+            <menubutton b-on="DOMContentLoaded,click"><icon>{{ .label }}</icon></menubutton>
+        `,
+        props: {
+            label: '💻',
+            inFullScreen: false
+        },
+        eventsListeners: {
+            DOMContentLoaded: function(event, _this, binding) {
+                var c = this;
+
+                // Hide this button for non-desktop browsers. Android is the only exception, since fullscreen works nicely.
+                var isDesktopBrowser = Helpers.isDesktopBrowser();
+                if (!isDesktopBrowser) {
+                    c.rootElement.style.display = 'none';
+                }
+            },
+            click: function(event) {
+                var c = this;
+
+                if (Helpers.isFullScreen()) {
+                    if (State.debug) {
+                        console.log('[menu_home_fullscreenbutton] exiting full screen');
+                    }
+                    Helpers.exitFullScreen();
+                }else {
+                    if (State.debug) {
+                        console.log('[menu_home_fullscreenbutton] entering full screen');
+                    }
+                    Helpers.enterFullScreen();
+                }
+
+                // Focus on the student response
+                Components.response.methods.focus(Components.response);
             }
         }
     });


### PR DESCRIPTION
Most desktop browsers include a native fullscreen function (e.g. F11 on desktop firefox, chrome, or CMD+CTRL+F on safari). However some simple users do not know how to enter fullscreen.

For the benefit of point-and-click users, a menu button is added in the Home scene for programmatic fullscreen entrance or exit.

Possible downsides:
- The UI would no longer be as straightforward as having one menu button for settings
- In programatic fullscreen, the usual ESC hotkey to navigate between Home and Environment will first exit fullscreen. Currently suppression of the ESC key by using `e.preventDefault()` doesn't seem to work in Firefox and Chrome, very likely due to the the native enforcement of ESC as the way to exit from a programmatic fullscreen.

Note: On desktop safari, in fullscreen on `document.documentElement`, `document.body`'s background applies to its actual height (leaving the html element's default white background at the bottom of the remainder of the vertical screen estate). The solution is to use `height: 100%` for both `html` and `body` elements.

This has been tested on Mac and Windows browsers, iOS and Android. Fullscreen button will show for Android browsers but not for iOS browsers.