### PR TITLE
Fix (favorite): Fix favourite not being copied to clipboard on mobile and desktop Safari

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,7 @@ var Helpers = function () {
             document.body.appendChild(textarea);
 
             // Synchronous copy
+            textarea.focus();
             textarea.select();
             var result = document.execCommand('copy');
 


### PR DESCRIPTION
This bug affects desktop and mobile safari. The solution is to focus and select the text to copy.