### PR TITLE
Fix (development): Explicitly declare 'default' network in docker-compose.yml services

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -5,6 +5,8 @@ services:
     image: nginx:1.14-alpine
     # Enable labels for traefik
     labels:
+      # Override the network that traefik should use
+      # - "traefik.docker.network=<project_name>_default"
       # traefik v1
       - "traefik.port=80"
       - "traefik.frontend.entryPoints=web"
@@ -19,20 +21,24 @@ services:
       - "traefik.http.routers.web.middlewares=nocache"
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Cache-Control=private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Pragma=no-cache"
+    networks:
+      - default
     volumes:
       - ./:/usr/share/nginx/html:ro
 
   # Run traefik v1 on port 8081
   traefik-v1:
     image: traefik:v1.7-alpine
-    ports:
-      - 8081:80
     command:
       # - --logLevel=DEBUG
       - --docker
       - --docker.watch
       - --docker.exposedByDefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
       - --entryPoints=Name:web Address::80
+    networks:
+      - default
+    ports:
+      - 8081:80
     volumes:
       # Allow traefik to listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -40,17 +46,20 @@ services:
   # Run traefik v2 on port 8080
   traefik-v2:
     image: traefik:v2.4
-    ports:
-      - 8080:80
     command:
       # - --log.level=DEBUG
       - --providers.docker=true
       - --providers.docker.exposedbydefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
       - --entrypoints.web.address=:80
+    networks:
+      # The default '<project_name>_default' network
+      - default
+    ports:
+      - 8080:80
     volumes:
       # Allow traefik to listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
-# The '<project_name>_default' network is created by docker-compose by default
-# networks:
-#   default:
+networks:
+  # The default '<project_name>_default' network
+  default:


### PR DESCRIPTION
Fixes lack of explicit declaration of 'default' network in #258. Being explicit makes the docker-compose stack clearer to developers.

Arranges keys for better readability.