### PR TITLE
Enhancement (speech): Show '↵' symbol when a newline (i.e. ENTER key) is expected

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -694,15 +694,17 @@ var Bubble = function(default_value) {
         // Always add a 1px placeholder at the beginning
         var html = '<character class="line-feed-placeholder"></character>';
 
-        var isLineFeed, _prependHtml, _classHtml, invalidFound = false;
+        var isLineFeed, _prependHtml, _classHtml, invalidFound = false, _appendHtml;
         for (var i = 0; i < truth.value.length; i++) {
             isLineFeed = /\n/.test(truth.value[i]) ? true : false;
 
             _prependHtml = '';
             _classHtml = '';
+            _appendHtml = '';
             if (isLineFeed) {
-                _prependHtml = '<br />';
-                _classHtml = 'line-feed ';
+                // _prependHtml = '<br />';
+                // _classHtml = 'line-feed ';
+                _appendHtml = '<br />';
             }
             if (environment.perfection === true) {
                 if (!invalidFound && i === bubble.value.length) {
@@ -722,7 +724,7 @@ var Bubble = function(default_value) {
                     _classHtml += 'valid';
                 }
             }
-            html += _prependHtml + '<character class="' + _classHtml + '">' + ( isLineFeed === true ? '' :  Helpers.htmlEntities(truth.value[i]) ) + '</character>';
+            html += _prependHtml + '<character class="' + _classHtml + '">' + ( isLineFeed === true ? '↵' :  Helpers.htmlEntities(truth.value[i]) ) + '</character>' + _appendHtml;
         }
         return html;
     }


### PR DESCRIPTION
Closes #265

Previously, whenever a new line is expected by the Trainer, the Trainer speech shows the expectation as a 2px thin character indicator at the beginning of a line. However, this had downsides: It was difficult to notice, not intuitive for new Students, and scrolls the Trainer speech to a next line which might have been inconsistent with Student expectation that a new line (i.e. ENTER key) should be typed at the end of their current line.

This change should make it more apparant to especially new Students to type the ENTER key at the end of each line (or, in the unix understanding, the start of a new line or paragraph). Benefits: The '↵' character is more apparant, more intuitive for first time Students, and now that the Trainer speech does not scroll to the next line before a newline (i.e ENTER key) is entered would be more consistent with Student expectation that a new line should be typed at the end of the Student's current line and that the Trainer speech cursor should be mirror Student progress.