### PR TITLE
Enhancement (speech): Remove Trainer's Speech cursor fading animation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -218,7 +218,7 @@ speech value character.line-feed {
 speech value character.cursor {
     display: inline-block;
     border: 1px solid #fff;
-    animation: blink 0.77s linear infinite;
+    /* animation: blink 0.77s linear infinite; */
 }
 @keyframes blink {
     /* 0% {


### PR DESCRIPTION
Closes #267

Previously, the Trainer's speech cursor had a fading animation. However this might distract the Student and subconsciously appear as errors, especially if the Student types with a high error rate.

Now, the animation of the Trainer cursor is removed, and it remains a static solid color. This should reduce Student subconscious distractions thereby increasing reading and typing flow.