### PR TITLE
Enhancement (response): Replace native scrollbar with a more beautiful scrollbar for non-Mac desktop browsers

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -286,6 +286,42 @@ response textareawrapper {
     border-radius: 1.75vw;
     cursor: text;
 }
+response textareawrapper box {
+    display: block;
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden; /* hide the scrollbox's scrollbar */
+}
+response textareawrapper box textarea {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow-y: scroll;
+}
+response textareawrapper box scrollbar {
+    position: absolute;
+    z-index: 1000;
+    top: 0;
+    right: 0.2vw; /* follow the macOS scrollbar */
+    width: 8px;
+    height: 0%;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 1vw;
+    background: none;
+    opacity: 0;
+}
+@keyframes scrollbarfadeout {
+    0% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
 response textarea {
     display: block;
     width: 100%;


### PR DESCRIPTION
Related: #259

This hides the amendable response element's scrollbar for non-Mac desktop browsers with non-zero-width native scrollbar in overflow.

The native scrollbar for all other client browsers remain intact.

