### PR TITLE
Refactor (development): Use traefik v2 only and constraint traefik to project in `docker-compose.yml`

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=touchtypie

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.*
+!/.env
 !/.github
 !/.gitignore
 !/.vscode

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "docker-compose up",
+            "type": "shell",
+            "command": "docker-compose up",
+        },
+        {
+            "label": "docker-compose -f docker-compose.traefik.yml up",
+            "type": "shell",
+            "command": "docker-compose -f docker-compose.traefik.yml up",
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,21 @@ In contrast to reading alone, typing while reading engages the visual, linguisti
 
 ## Development
 
-It started out simple, but grew just enough to require a custom frontend framework. Most parts of are is still in pure HTML, CSS, JS.
+Available as [vscode tasks](.vscode/tasks.json).
+
+```sh
+docker-compose up
+# Site now available on http://localhost:8080
+```
+
+Alternatively, if you need to disable caching when working behind a reverse proxy:
+
+```sh
+docker-compose -f docker-compose.traefik.yml up
+# Site now available on http://localhost:8080
+```
+
+The project started out simple, but grew just enough to require a custom frontend framework. Most parts of are is still in pure HTML, CSS, JS.
 
 ## Practice resources
 

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,19 +1,14 @@
+# Creates an nginx, proxied by traefik on port 8080, with caching disabled using Cache-Control HTTP headers. This is useful when working behind a reverse proxy, e.g. cloudflare.
 version: '2.2'
 services:
-
   web:
     image: nginx:1.14-alpine
     # Enable labels for traefik
     labels:
-      # Override the network that traefik should use
-      # - "traefik.docker.network=<project_name>_default"
-      # traefik v1
-      - "traefik.port=80"
-      - "traefik.frontend.entryPoints=web"
-      - "traefik.frontend.rule=HostRegexp:{catchall:.*}"
-      # - "traefik.frontend.rule=PathPrefix:/"
-      - "traefik.frontend.headers.customResponseHeaders=Cache-Control:private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0||Pragma:no-cache"
       # traefik v2
+      - "traefik.enable=true"
+      - 'custom.label=${COMPOSE_PROJECT_NAME}' # Constraint for traefik
+      # - "traefik.docker.network=${COMPOSE_PROJECT_NAME}_default" # Override the network that traefik should use
       - "traefik.http.services.web.loadbalancer.server.port=80"
       - "traefik.http.routers.web.entrypoints=web"
       - "traefik.http.routers.web.rule=HostRegexp(`{catchall:.*}`)"
@@ -22,26 +17,10 @@ services:
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Cache-Control=private, no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"
       - "traefik.http.middlewares.nocache.headers.customResponseHeaders.Pragma=no-cache"
     networks:
+      # The default '${COMPOSE_PROJECT_NAME}_default' network
       - default
     volumes:
-      - ./:/usr/share/nginx/html:ro
-
-  # Run traefik v1 on port 8081
-  traefik-v1:
-    image: traefik:v1.7-alpine
-    command:
-      # - --logLevel=DEBUG
-      - --docker
-      - --docker.watch
-      - --docker.exposedByDefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
-      - --entryPoints=Name:web Address::80
-    networks:
-      - default
-    ports:
-      - 8081:80
-    volumes:
-      # Allow traefik to listen to the Docker events
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - .:/usr/share/nginx/html:ro
 
   # Run traefik v2 on port 8080
   traefik-v2:
@@ -49,10 +28,11 @@ services:
     command:
       # - --log.level=DEBUG
       - --providers.docker=true
-      - --providers.docker.exposedbydefault=true # Make traefik proxy over the default network created by docker-compose, i.e. '<project_name>_default'. This makes this configuration portable to any project.
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.constraints=Label(`custom.label`,`${COMPOSE_PROJECT_NAME}`)
       - --entrypoints.web.address=:80
     networks:
-      # The default '<project_name>_default' network
+      # The default '${COMPOSE_PROJECT_NAME}_default' network
       - default
     ports:
       - 8080:80
@@ -61,5 +41,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
 networks:
-  # The default '<project_name>_default' network
+  # The default '${COMPOSE_PROJECT_NAME}_default' network
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: '2.2'
 services:
-
   web:
     image: nginx:1.14-alpine
     ports:
       - 8080:80
     volumes:
-      - ./:/usr/share/nginx/html:ro
+      - .:/usr/share/nginx/html:ro


### PR DESCRIPTION
Previously, `docker-compose.yml` `traefik` was enabled for all `docker` provider containers. However, if multiple `traefik` instances ran on the same machine, their configuration on containers would conflict with one another and proxying fails. Hence project-level constraints are needed.

Now, project-level constraints for `traefik` is achieved in `docker-compose.yml` by:
- disabling traefik proxying of all containers, and adding `traefik.enable=true` to services to be proxied
- adding [`.env`](https://docs.docker.com/compose/environment-variables/#the-env-file) containing an env var [`COMPOSE_PROJECT_NAME=<project_name>`](https://docs.docker.com/compose/reference/envvars/#compose_project_name). The value of  `COMPOSE_PROJECT_NAME` is the project directory's basename.
- upon `docker-compose up`, the `.env` file is read  (for `docker-compose` `1.28+` and above), and `COMPOSE_PROJECT_NAME` is interpolated in the newly added `project.name=${COMPOSE_PROJECT_NAME}` docker label of each to-be-proxied service, as well as the [constraint](https://doc.traefik.io/traefik/providers/docker/#constraints) for `traefik`.

Benefits:
- Reusable `docker-compose.yml` across projects
- Multiple `traefik` on the same machine without conflicts
- Development unchanged i.e. `docker-compose up` or `docker-compose -f <file> up`.