### PR TITLE
Refactor (development): Rename traefik constraint label to `project.name`  in `docker-compose.yml`

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -7,7 +7,7 @@ services:
     labels:
       # traefik v2
       - "traefik.enable=true"
-      - 'custom.label=${COMPOSE_PROJECT_NAME}' # Constraint for traefik
+      - 'project.name=${COMPOSE_PROJECT_NAME}' # Constraint for traefik
       # - "traefik.docker.network=${COMPOSE_PROJECT_NAME}_default" # Override the network that traefik should use
       - "traefik.http.services.web.loadbalancer.server.port=80"
       - "traefik.http.routers.web.entrypoints=web"
@@ -29,7 +29,7 @@ services:
       # - --log.level=DEBUG
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --providers.docker.constraints=Label(`custom.label`,`${COMPOSE_PROJECT_NAME}`)
+      - --providers.docker.constraints=Label(`project.name`,`${COMPOSE_PROJECT_NAME}`)
       - --entrypoints.web.address=:80
     networks:
       # The default '${COMPOSE_PROJECT_NAME}_default' network


### PR DESCRIPTION
Related: #276

Renames label to what was expected in #276.